### PR TITLE
Fix pstore database path, change from relative to absolute.

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -6,7 +6,7 @@ require 'tempfile'
 
 puts 'downloading...'
 
-data = PStore.new('lib/polish_postal_codes.pstore')
+data = PStore.new(File.expand_path('../../lib/polish_postal_codes.pstore', __FILE__))
 tmp_file = Tempfile.new('spispna.pdf')
 tmp_file.write(open('https://www.poczta-polska.pl/hermes/uploads/2013/11/spispna.pdf').read)
 tmp_file.flush

--- a/lib/polish_postal_codes.rb
+++ b/lib/polish_postal_codes.rb
@@ -3,7 +3,7 @@ require 'pstore'
 
 module PolishPostalCodes
   class Info
-    DATA = PStore.new('lib/polish_postal_codes.pstore')
+    DATA = PStore.new(File.expand_path('../polish_postal_codes.pstore', __FILE__))
 
     def self.get(postal_code)
       DATA.transaction(true) { |postal_codes| postal_codes[postal_code] }


### PR DESCRIPTION
Method PolishPostalCodes::Info.get was not working in Rails application when database path was relative.
